### PR TITLE
Add Hindi city names

### DIFF
--- a/routes/apiRoutes.js
+++ b/routes/apiRoutes.js
@@ -2,25 +2,6 @@ const express = require("express");
 const tweetController = require("../controllers/tweet");
 const router = express.Router();
 
-const cities = require("../data/newCities.json");
-const topCities = require("../data/cities.json");
-const resources = require("../data/resources.json");
-
-router.get("/cities", async (req, res) => {
-    let resCities = [];
-
-    for (let state in cities) {
-        for (cityName in cities[state]) {
-            resCities.push({ name: cityName, top: cityName in topCities });
-        }
-    }
-    return res.status(200).send(resCities);
-});
-
-router.get("/resources", async (req, res) => {
-    return res.status(200).send(resources);
-});
-
 /**
  * @swagger
  * /api/:

--- a/routes/meta.js
+++ b/routes/meta.js
@@ -19,7 +19,7 @@ const router = express.Router();
  *         description: get a complete list of all available cities
  *         responses:
  *             '200':
- *                 description: An array of city objects containg the hindi and english name and a top boolean indicator
+ *                 description: An array of city objects containing the Hindi and English name and a top boolean indicator
  *                 schema:
  *                     type: object
  *                     properties:

--- a/routes/meta.js
+++ b/routes/meta.js
@@ -1,21 +1,78 @@
 const fs = require("fs");
 const express = require("express");
 
-const cities = require("fs")
+const citiesRaw = require("fs")
     .readFileSync("./data/cities.csv", "utf8")
     .split("\n")
     .map((row) => row.split(","));
+
+const cities = require("../data/newCities.json");
+const topCities = require("../data/cities.json");
+const resources = require("../data/resources.json");
 
 const router = express.Router();
 
 /**
  * @swagger
+ * /api/cities:
+ *     get:
+ *         description: get a complete list of all available cities
+ *         responses:
+ *             '200':
+ *                 description: An array of city objects containg the hindi and english name and a top boolean indicator
+ *                 schema:
+ *                     type: object
+ *                     properties:
+ *                         name:
+ *                             type: string
+ *                             description: The English name of the city
+ *                         hindiName:
+ *                             type: string
+ *                             descriptiom: The Hindi name of the city
+ *                         top:
+ *                             type: boolean
+ *                             description: A boolean indicating whether or not a city should be prominently displayed on the frontend
+ *
+ *
+ */
+router.get("/cities", async (req, res) => {
+    let resCities = [];
+
+    for (let state in cities) {
+        for (cityName in cities[state]) {
+            let cityObj = {};
+            cityObj.name = cityName;
+            cityObj.top = cityName in topCities;
+            for ([en, hi] of citiesRaw) {
+                if (en == cityName) cityObj.hindiName = hi.slice(0, -2);
+            }
+            resCities.push(cityObj);
+        }
+    }
+    return res.status(200).send(resCities);
+});
+
+/**
+ * @swagger
+ * /api/resources:
+ *     get:
+ *     description: Get a list of resources
+ *     responses:
+ *         '200':
+ *             description: An array of all available resources
+ */
+router.get("/resources", async (req, res) => {
+    return res.status(200).send(resources);
+});
+
+/**
+ * @swagger
  * /api/checkCity:
- *  get:
- *    description: Check if city name is valid
- *    responses:
- *      '200':
- *        description: A response object with `found` boolean field and name locale code
+ *     get:
+ *     description: Check if city name is valid
+ *     responses:
+ *         '200':
+ *             description: A response object with `found` boolean field and name locale code
  */
 router.get("/checkCity", (req, res) => {
     let { city } = req.query;
@@ -26,7 +83,7 @@ router.get("/checkCity", (req, res) => {
 
     city = city.toLowerCase();
 
-    for (const [en, hi] of cities) {
+    for (const [en, hi] of citiesRaw) {
         if (city == en.toLowerCase() || city == hi) {
             return res.send({ found: true, name: en });
         }

--- a/server.js
+++ b/server.js
@@ -36,7 +36,7 @@ const swaggerOptions = {
         },
     },
     // ['.routes/*.js']
-    apis: ["routes/apiRoutes.js"],
+    apis: ["routes/apiRoutes.js", "routes/meta.js"],
 };
 
 //setup Swagger for auto documentation


### PR DESCRIPTION
added Hindi names to the `/cities` response object

```yaml
 * /api/cities:
 *     get:
 *         description: get a complete list of all available cities
 *         responses:
 *             '200':
 *                 description: An array of city objects containing the Hindi and English name and a top boolean indicator
 *                 schema:
 *                     type: object
 *                     properties:
 *                         name:
 *                             type: string
 *                             description: The English name of the city
 *                         hindiName:
 *                             type: string
 *                             descriptiom: The Hindi name of the city
 *                         top:
 *                             type: boolean
 *                             description: A boolean indicating whether or not a city should be prominently displayed on the frontend
 *
 *
 */
```