### PR TITLE
Standard format for storing phone numbers

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -77,11 +77,7 @@ const parsePhoneNumbers = (text) => {
                     || []
                     )
                 .map(phone => phone.replace(/\s+|-/g, ""))
-                .map(phone => 
-                    phone[0] == "0" || phone.length < 0 ? 
-                        phone : 
-                        phone.substring(phone.length - 10)
-                    )
+                .map(phone => phone.substring(phone.length - 10))
             )
     ].filter(_=>_);
 };

--- a/parser.js
+++ b/parser.js
@@ -65,14 +65,26 @@ const phoneRegex =
 const emailRegex =
     /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/g;
 
-const parsePhoneNumbers = (text) =>
-    [
+    
+const parsePhoneNumbers = (text) => {
+    return [
         ...new Set(
-            (text.match(phoneRegex) || []).concat(
-                text.replace(/\s+/g, "@").match(phoneRegex) || []
+            (text.match(phoneRegex) || [])
+                .concat(
+                    text
+                        .replace(/\s+/g, "@")
+                        .match(phoneRegex)
+                    || []
+                    )
+                .map(phone => phone.replace(/\s+|-/g, ""))
+                .map(phone => 
+                    phone[0] == "0" || phone.length < 0 ? 
+                        phone : 
+                        phone.substring(phone.length - 10)
+                    )
             )
-        ),
-    ] || [];
+    ].filter(_=>_);
+};
 
 const parseTweet = (raw_text) => {
     const text = normalize(raw_text);

--- a/parser.js
+++ b/parser.js
@@ -65,7 +65,7 @@ const phoneRegex =
 const emailRegex =
     /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/g;
 
-    
+
 const parsePhoneNumbers = (text) => {
     return [
         ...new Set(
@@ -77,7 +77,13 @@ const parsePhoneNumbers = (text) => {
                     || []
                     )
                 .map(phone => phone.replace(/\s+|-/g, ""))
-                .map(phone => phone.substring(phone.length - 10))
+                .map(phone =>
+                    phone.length == 10 ?
+                        phone :
+                        phone.length > 10 && phone[0] == "0" ?
+                            phone.substring(0, 11) :
+                            phone.substring(phone.length - 10)
+                    )
             )
     ].filter(_=>_);
 };


### PR DESCRIPTION
Skip all spaces and country codes, store 11 digits starting with a zero for landline numbers, and 10 digits for mobile numbers.